### PR TITLE
Organise README to match other Unruly repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # co.unruly.control
 
 [![Build Status](https://travis-ci.org/unruly/control.svg?branch=master)](https://travis-ci.org/unruly/control)
+[![Release Version](https://img.shields.io/maven-central/v/co.unruly/control.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22co.unruly%22%20AND%20a%3A%22control%22)
 [![Javadocs](https://www.javadoc.io/badge/co.unruly/control.svg)](https://www.javadoc.io/doc/co.unruly/control)
 
 Control is a collection of functional control-flow primitives and utilities, built around a 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
-[![Build Status](https://travis-ci.org/unruly/control.svg?branch=master)](https://travis-ci.org/unruly/control)
+# co.unruly.control
 
+[![Build Status](https://travis-ci.org/unruly/control.svg?branch=master)](https://travis-ci.org/unruly/control)
 [![Javadocs](https://www.javadoc.io/badge/co.unruly/control.svg)](https://www.javadoc.io/doc/co.unruly/control)
 
-## Maven
+Control is a collection of functional control-flow primitives and utilities, built around a 
+[`Result`](https://javadoc.io/page/co.unruly/control/latest/co/unruly/control/result/Result.html) type.
+
+## Installation
+
+### Using Maven
+
+Add this dependency to your `pom.xml`.
+
 ```xml
 <dependency>
     <groupId>co.unruly</groupId>
     <artifactId>control</artifactId>
-    <version>0.8.6</version>
+    <version>0.8.12</version>
 </dependency>
 ```
 
-## Control
+## Documentation
 
-co.unruly.Control is a collection of functional control-flow primitives and utilities, built around a 
-[`Result`](https://javadoc.io/page/co.unruly/control/latest/co/unruly/control/result/Result.html) type.
+- [JavaDoc](https://www.javadoc.io/doc/co.unruly/control)
+
+## Examples
 
 ### Result
 


### PR DESCRIPTION
I've adjusted the README and changed a bit of the wording to match other projects like [unruly/java-8-matchers](https://github.com/unruly/java-8-matchers).

Since there are JavaDocs available, I also added a Documentation section to make that clear.

i.e. Header -> Badges -> Description -> Installation -> Documentation -> Examples
